### PR TITLE
fixing mount of overlay filesystem

### DIFF
--- a/bin/library.sh
+++ b/bin/library.sh
@@ -53,12 +53,8 @@ test_overlay_workdir_needed () {
 }
 
 get_overlay_type_name () {
-    local kernel=$(uname -r)
-    local major=$(echo $kernel | cut -f 1 -d '.')
-    local minor=$(echo $kernel | cut -f 2 -d '.')
-
-    if [ "$major" -ge "3" ] ||
-    [ "$major" -eq "3" -a "$minor" -ge "18" ]; then
+    # test for kernel version >=3.18
+    if test_overlay_workdir_needed; then
         echo "overlay"    # use new identifier
     else
         echo "overlayfs" # use old identifier

--- a/bin/library.sh
+++ b/bin/library.sh
@@ -51,3 +51,16 @@ test_overlay_workdir_needed () {
     [ "$major" -gt "3" ] ||
     [ "$major" -eq "3" -a "$minor" -gt "17" ]
 }
+
+get_overlay_type_name () {
+    local kernel=$(uname -r)
+    local major=$(echo $kernel | cut -f 1 -d '.')
+    local minor=$(echo $kernel | cut -f 2 -d '.')
+
+    if [ "$major" -gt "3" ] ||
+    [ "$major" -eq "3" -a "$minor" -gt "18" ]; then
+        echo "overlay"    # use new identifier
+    else
+        echo "overlayfs" # use old identifier
+    fi
+}

--- a/bin/library.sh
+++ b/bin/library.sh
@@ -57,8 +57,8 @@ get_overlay_type_name () {
     local major=$(echo $kernel | cut -f 1 -d '.')
     local minor=$(echo $kernel | cut -f 2 -d '.')
 
-    if [ "$major" -gt "3" ] ||
-    [ "$major" -eq "3" -a "$minor" -gt "18" ]; then
+    if [ "$major" -ge "3" ] ||
+    [ "$major" -eq "3" -a "$minor" -ge "18" ]; then
         echo "overlay"    # use new identifier
     else
         echo "overlayfs" # use old identifier

--- a/bin/mount-iso
+++ b/bin/mount-iso
@@ -28,11 +28,11 @@ if test_overlay_workdir_needed ; then
     workdiropt='-oworkdir='$ISOMNT_WORK
 fi
 
-$SUDO $MOUNT -t overlayfs \
+$SUDO $MOUNT -t overlay \
              -olowerdir=$ISOMNT_RO \
              -oupperdir=$ISOMNT_RW \
              $workdiropt \
-             overlayfs $ISOMNT_RW || \
+             overlay $ISOMNT_RW || \
     die Mounting of Ubuntu ISO read-write overlay failed!
 
 exit 0

--- a/bin/mount-iso
+++ b/bin/mount-iso
@@ -28,7 +28,7 @@ if test_overlay_workdir_needed ; then
     workdiropt='-oworkdir='$ISOMNT_WORK
 fi
 
-$SUDO $MOUNT -t overlay \
+$SUDO $MOUNT -t $(get_overlay_type_name) \
              -olowerdir=$ISOMNT_RO \
              -oupperdir=$ISOMNT_RW \
              $workdiropt \

--- a/bin/mount-rootfs
+++ b/bin/mount-rootfs
@@ -24,7 +24,7 @@ if test_overlay_workdir_needed ; then
     workdiropt='-oworkdir='$ROOTFSMNT_WORK
 fi
 
-$SUDO $MOUNT -t overlay \
+$SUDO $MOUNT -t $(get_overlay_type_name) \
              -olowerdir=$ROOTFSMNT_RO \
              -oupperdir=$ROOTFSMNT_RW \
              $workdiropt \

--- a/bin/mount-rootfs
+++ b/bin/mount-rootfs
@@ -24,11 +24,11 @@ if test_overlay_workdir_needed ; then
     workdiropt='-oworkdir='$ROOTFSMNT_WORK
 fi
 
-$SUDO $MOUNT -t overlayfs \
+$SUDO $MOUNT -t overlay \
              -olowerdir=$ROOTFSMNT_RO \
              -oupperdir=$ROOTFSMNT_RW \
              $workdiropt \
-             overlayfs $ROOTFSMNT_RW || \
+             overlay $ROOTFSMNT_RW || \
     die Mounting of Ubuntu root filesystem read-write overlay failed!
 
 exit 0


### PR DESCRIPTION
In current Ubuntu 16.04.2 with Kernel 4.8.0-39-generic, (mount is from util-linux 2.27.1 (libmount 2.27.0)), make fails while mounting the overlay filesystem using mount-iso and mount-rootfs with

    mount: unknown filesystem type 'overlayfs'

Calling

    mount -t overlayfs

is deprecated, since it has been merged to mainline it shall be used with

    mount -t overlay

See https://www.kernel.org/doc/Documentation/filesystems/overlayfs.txt